### PR TITLE
DNM: Red Hat 7.7 Compatibility

### DIFF
--- a/krping.c
+++ b/krping.c
@@ -74,6 +74,15 @@
 #define pci_unmap_addr_set         dma_unmap_addr_set
 
 #endif
+
+#define ib_post_send(qp, wr, bad_wr)\
+	ib_post_send(qp, (const struct ib_send_wr *)wr,\
+		     (const struct ib_send_wr **)bad_wr)
+
+#define ib_post_recv(qp, wr, bad_wr)\
+	ib_post_recv(qp, (const struct ib_recv_wr *)wr,\
+		     (const struct ib_recv_wr **)bad_wr)
+
 static int debug = 0;
 module_param(debug, int, 0);
 MODULE_PARM_DESC(debug, "Debug level (0=none, 1=all)");


### PR DESCRIPTION
This PR adds RHEL 7.7 Compatibility. It makes two changes:
- `#define` PCI api calls to the DMA api equivalents
- Cast WR Pointers in `ib_post_send()` and `ib_post_recv()` arguments to const

The second of the changes is not done is a portable way, and this change would cause issues when compiling on RHEL7.6 and below. @larrystevenwise do you have a preferred way to do configuration for this kind of infiniband function signature change?