### PR TITLE
Hold private mutex while invoking rdma_accept()

### DIFF
--- a/krping.c
+++ b/krping.c
@@ -460,7 +460,9 @@ static int krping_accept(struct krping_cb *cb)
 	conn_param.responder_resources = 1;
 	conn_param.initiator_depth = 1;
 
+	rdma_lock_handler(cb->child_cm_id);
 	ret = rdma_accept(cb->child_cm_id, &conn_param);
+	rdma_unlock_handler(cb->child_cm_id);
 	if (ret) {
 		printk(KERN_ERR PFX "rdma_accept error: %d\n", ret);
 		return ret;


### PR DESCRIPTION
RDMA core mutex locking was restructured by commit d114c6feedfe ("RDMA/cma: Add missing locking to rdma_accept()"). According to the commit, rdma_accept() should be called from CM event handler. Hold private mutex while invoking rdma_accept() to avoid lockdep warn.

[  564.563873] accepting client connection request [  564.568680] ------------[ cut here ]------------ [  564.573359] WARNING: CPU: 0 PID: 3932 at drivers/infiniband/core/cma.c:4658 rdma_accept+0x503/0x7d0 [rdma_cm]
[  564.639745] CPU: 0 UID: 0 PID: 3932 Comm: sh Kdump: loaded Tainted: G S         OE       6.16.7-200.fc42.x86_64+debug #1 PREEMPT(lazy)
[  564.651956] Tainted: [S]=CPU_OUT_OF_SPEC, [O]=OOT_MODULE, [E]=UNSIGNED_MODULE
[  564.659124] Hardware name: Powerleader PR1715R/X9DRD-iF, BIOS 3.3 09/10/2018
[  564.666276] RIP: 0010:rdma_accept+0x503/0x7d0 [rdma_cm]
[  564.671570] Code: 0f 8e 5a 01 00 00 88 93 b0 04 00 00 e9 27 fc ff ff 48 8d bb 50 04 00 00 be ff ff ff ff e8 45 3f 6d f3 85 c0 0f 85 9f fb ff ff <0f> 0b e9 98 fb ff ff 4d 85 e4 0f 84 41 01 00 00 48 b8 00 00 00 00
[  564.690403] RSP: 0018:ffffc9000948f798 EFLAGS: 00010246
[  564.695674] RAX: 0000000000000000 RBX: ffff888117e92000 RCX: 0000000000000000
[  564.703094] RDX: 0000000000000000 RSI: ffffffffb600ed78 RDI: ffffffffb54b9d00
[  564.710289] RBP: 1ffff92001291ef6 R08: 0000000000000001 R09: 0000000000000000
[  564.717464] R10: 0000000000000000 R11: 0000000000000001 R12: ffffc9000948f8c0
[  564.724626] R13: ffff88810a388000 R14: ffff8881179d6390 R15: 0000000000000000
[  564.731794] FS:  00007fa0ac858740(0000) GS:ffff88823cd20000(0000) knlGS:0000000000000000
[  564.739914] CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
[  564.745712] CR2: 00007fc7ecf5eab0 CR3: 000000017c96e002 CR4: 00000000001726f0
[  564.752883] Call Trace:
[  564.755371]  <TASK>
[  564.757518]  ? __pfx_rdma_accept+0x10/0x10 [rdma_cm]
[  564.762551]  ? krping_setup_buffers.cold+0xd1/0x109 [rdma_krping]
[  564.768716]  krping_run_server+0x23b/0x710 [rdma_krping]
[  564.774092]  ? __pfx_krping_run_server+0x10/0x10 [rdma_krping]
[  564.779975]  ? __pfx_krping_cma_event_handler+0x10/0x10 [rdma_krping]
[  564.786477]  ? __pfx__printk+0x10/0x10
[  564.790287]  ? rdma_restrack_new+0x94/0xe0 [ib_core]
[  564.795624]  ? __rdma_create_id+0x5b5/0x760 [rdma_cm]
[  564.800763]  krping_doit+0xd8f/0x1070 [rdma_krping]
[  564.805697]  ? __pfx_krping_doit+0x10/0x10 [rdma_krping]
[  564.811061]  ? __pfx__printk+0x10/0x10
[  564.814885]  krping_write_proc+0xb2/0x102 [rdma_krping]
[  564.820174]  proc_reg_write+0x1c3/0x3c0
[  564.824071]  vfs_write+0x1d0/0xf80
[  564.827526]  ? __pfx_vfs_write+0x10/0x10
[  564.831491]  ? __pfx_locks_remove_posix+0x10/0x10
[  564.836271]  ksys_write+0xff/0x200
[  564.840150]  ? __pfx_ksys_write+0x10/0x10
[  564.844231]  ? fput_close_sync+0x14f/0x1b0
[  564.848395]  do_syscall_64+0x98/0x350
[  564.852124]  ? lockdep_hardirqs_on+0x8c/0x130
[  564.856526]  ? entry_SYSCALL_64_after_hwframe+0x76/0x7e
[  564.861787]  ? do_syscall_64+0x13b/0x350
[  564.865758]  ? do_raw_spin_unlock+0x59/0x230
[  564.870070]  ? do_fcntl+0x78a/0xf80
[  564.873631]  ? _raw_spin_unlock+0x2d/0x50
[  564.877694]  ? do_fcntl+0x78a/0xf80
[  564.881228]  ? get_close_on_exec+0x10a/0x230
[  564.885545]  ? __pfx_do_fcntl+0x10/0x10
[  564.889437]  ? entry_SYSCALL_64_after_hwframe+0x76/0x7e
[  564.894701]  ? do_syscall_64+0x13b/0x350
[  564.898684]  ? lockdep_hardirqs_on+0x8c/0x130
[  564.903087]  ? entry_SYSCALL_64_after_hwframe+0x76/0x7e
[  564.908352]  ? do_syscall_64+0x13b/0x350
[  564.912317]  ? lockdep_hardirqs_on+0x8c/0x130
[  564.916714]  ? entry_SYSCALL_64_after_hwframe+0x76/0x7e
[  564.921976]  ? do_syscall_64+0x13b/0x350
[  564.925953]  entry_SYSCALL_64_after_hwframe+0x76/0x7e
[  564.931296] RIP: 0033:0x7fa0ac8c977e
[  564.934945] Code: 4d 89 d8 e8 d4 bc 00 00 4c 8b 5d f8 41 8b 93 08 03 00 00 59 5e 48 83 f8 fc 74 11 c9 c3 0f 1f 80 00 00 00 00 48 8b 45 10 0f 05 <c9> c3 83 e2 39 83 fa 08 75 e7 e8 13 ff ff ff 0f 1f 00 f3 0f 1e fa
[  564.953747] RSP: 002b:00007ffc86e19460 EFLAGS: 00000202 ORIG_RAX: 0000000000000001
[  564.961357] RAX: ffffffffffffffda RBX: 000000000000002f RCX: 00007fa0ac8c977e
[  564.968522] RDX: 000000000000002f RSI: 000055d6036e58a0 RDI: 0000000000000001
[  564.975692] RBP: 00007ffc86e19470 R08: 0000000000000000 R09: 0000000000000000
[  564.982858] R10: 0000000000000000 R11: 0000000000000202 R12: 000000000000002f
[  564.990025] R13: 000055d6036e58a0 R14: 00007fa0aca445c0 R15: 0000000000000000
[  564.997238]  </TASK>
[  564.999465] Kernel panic - not syncing: kernel: panic_on_warn set ...